### PR TITLE
Updates to CSS and directive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           keys:
             - cache-pip
 
-      - run: pip install --user -e .[sphinx,rtd]
+      - run: pip install --user .[sphinx,rtd]
       - save_cache:
           key: cache-pip
           paths:

--- a/docs/jupyter_sphinx.md
+++ b/docs/jupyter_sphinx.md
@@ -17,7 +17,7 @@ code execution with minimal effort.
 You can use the `jupyter-execute` directive to embed code into the document
 
 ````
-```{jupyter-execute}
+```{execute}
 name = 'world'
 print('hello ' + name + '!')
 ```
@@ -25,7 +25,7 @@ print('hello ' + name + '!')
 
 The above is rendered as follows:
 
-```{jupyter-execute}
+```{execute}
 name = 'world'
 print('hello ' + name + '!')
 ```
@@ -36,11 +36,11 @@ is rendered directly after the code snippet.
 Because all code cells in a document are run in the same kernel, cells later in the document
 can use variables and functions defined in cells earlier in the document:
 
-```{jupyter-execute}
+```{execute}
 a = 1
 print('first cell: a = {}'.format(a))
 ```
-```{jupyter-execute}
+```{execute}
 a += 1
 print('second cell: a = {}'.format(a))
 ```
@@ -48,7 +48,7 @@ print('second cell: a = {}'.format(a))
 Because jupyter-sphinx uses the machinery of `nbconvert`, it is capable of rendering
 any rich output, for example plots:
 
-```{jupyter-execute}
+```{execute}
 
 import numpy as np
 from matplotlib import pyplot
@@ -63,14 +63,14 @@ pyplot.grid()
 
 LaTeX output:
 
-```{jupyter-execute}
+```{execute}
 
   from IPython.display import Latex
   Latex('∫_{-∞}^∞ e^{-x²}dx = \sqrt{π}')
 ```
 or even full-blown javascript widgets:
 
-```{jupyter-execute}
+```{execute}
 
 import ipywidgets as w
 from IPython.display import display
@@ -87,7 +87,7 @@ display(a, b)
 You may choose to hide the code of a cell, but keep its output visible using `:hide-code:`
 
 ````
-```{jupyter-execute}
+```{execute}
 :hide-code:
 
 print('this code is invisible')
@@ -96,7 +96,7 @@ print('this code is invisible')
 
 produces:
 
-```{jupyter-execute}
+```{execute}
 :hide-code:
 
 print('this code is invisible')
@@ -105,14 +105,14 @@ print('this code is invisible')
 or vice versa with ``:hide-output:``::
 
 ````
-```{jupyter-execute}
+```{execute}
 :hide-output:
 
 print('this output is invisible')
 ```
 ````
 
-```{jupyter-execute}
+```{execute}
 :hide-output:
 
 print('this output is invisible')
@@ -120,14 +120,14 @@ print('this output is invisible')
 
 You may also display the code *below* the output with ``:code-below:``::
 
-```{jupyter-execute}
+```{execute}
 :code-below:
 print('this output is above the code')
 ```
 
 You may also add *line numbers* to the source code with ``:linenos:``::
 
-```{jupyter-execute}
+```{execute}
 :linenos:
 
 print('A')

--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -1,7 +1,11 @@
 __version__ = "0.1.0"
 
 from docutils import nodes
-from jupyter_sphinx.execute import JupyterWidgetStateNode, JupyterWidgetViewNode
+from jupyter_sphinx.execute import (
+    JupyterWidgetStateNode,
+    JupyterWidgetViewNode,
+    JupyterCell,
+)
 from ipywidgets import embed
 from pathlib import Path
 
@@ -124,5 +128,6 @@ def setup(app):
     app.add_config_value("myst_nb_require_url", REQUIRE_URL_DEFAULT, "html")
     app.add_config_value("myst_nb_embed_url", None, "html")
     app.add_css_file("mystnb.css")
+    app.add_directive("execute", JupyterCell)
 
     return {"version": __version__, "parallel_read_safe": True}

--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -3,6 +3,7 @@ __version__ = "0.1.0"
 from docutils import nodes
 from jupyter_sphinx.execute import JupyterWidgetStateNode, JupyterWidgetViewNode
 from ipywidgets import embed
+from pathlib import Path
 
 from .parser import (
     NotebookParser,
@@ -13,6 +14,11 @@ from .parser import (
     CellImageNode,
 )
 from .transform import CellOutputsToNodes
+
+
+def static_path(app):
+    static_path = Path(__file__).absolute().with_name("_static")
+    app.config.html_static_path.append(str(static_path))
 
 
 def builder_inited(app):
@@ -114,6 +120,9 @@ def setup(app):
         "https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"
     )
     app.connect("builder-inited", builder_inited)
+    app.connect("builder-inited", static_path)
     app.add_config_value("myst_nb_require_url", REQUIRE_URL_DEFAULT, "html")
     app.add_config_value("myst_nb_embed_url", None, "html")
+    app.add_css_file("mystnb.css")
+
     return {"version": __version__, "parallel_read_safe": True}

--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -1,0 +1,52 @@
+/* Input cells */
+.cell_input div.highlight pre {
+  border: 1px #ccc solid;
+}
+
+/* All cell outputs */
+.cell_output {
+  margin-left: 1em;
+}
+
+/* Text outputs from cells */
+.cell_output .output.text_plain {
+  background: #fafafa;
+}
+
+.cell_output .output.text_plain * {
+  background: none
+}
+
+/* Pandas tables. Pulled from the Jupyter / nbsphinx CSS */
+div.cell_output table {
+    border: none;
+    border-collapse: collapse;
+    border-spacing: 0;
+    color: black;
+    font-size: 1em;
+    table-layout: fixed;
+  }
+  div.cell_output thead {
+    border-bottom: 1px solid black;
+    vertical-align: bottom;
+  }
+  div.cell_output tr,
+  div.cell_output th,
+  div.cell_output td {
+    text-align: right;
+    vertical-align: middle;
+    padding: 0.5em 0.5em;
+    line-height: normal;
+    white-space: normal;
+    max-width: none;
+    border: none;
+  }
+  div.cell_output th {
+    font-weight: bold;
+  }
+  div.cell_output tbody tr:nth-child(odd) {
+    background: #f5f5f5;
+  }
+  div.cell_output tbody tr:hover {
+    background: rgba(66, 165, 245, 0.2);
+  }

--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -8,6 +8,17 @@
   margin-left: 1em;
 }
 
+/* Outputs from jupyter_sphinx overrides to remove extra CSS */
+div.section div.jupyter_container {
+  padding: .4em;
+  margin: 0 0 .4em 0;
+  background-color: none;
+  border: none;
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+
 /* Text outputs from cells */
 .cell_output .output.text_plain {
   background: #fafafa;

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ setup(
     name="MyST-NB",
     version=version,
     description=(
-        "An extended commonmark compliant parser, " "with bridges to docutils & sphinx."
+        "A Jupyter Notebook Sphinx reader built on top of the MyST markdown parser."
     ),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/ExecutableBookProject/myst_nb",
-    author="Chris Sewell",
-    author_email="chrisj_sewell@hotmail.com",
-    license="MIT",
+    author="ExecutableBookProject",
+    author_email="choldgraf@berkeley.edu",
+    license="BSD-3",
     packages=find_packages(),
     entry_points={"console_scripts": []},
     classifiers=[
@@ -39,6 +39,7 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.5",
+    package_data={"myst_nb": ["_static/mystnb.css"]},
     install_requires=[
         "jupyter_sphinx",
         "nbformat",


### PR DESCRIPTION
This adds a few reasonable CSS rules for notebook outputs, and also adds an "execute" directive that we can start to use for the notebook representation of the MyST markdown file