### PR TITLE
fixing parser by adding newline

### DIFF
--- a/docs/notebooks.ipynb
+++ b/docs/notebooks.ipynb
@@ -339,9 +339,7 @@
     "    orientation='horizontal',\n",
     "    readout=True,\n",
     "    readout_format='d'\n",
-    ")\n",
-    "\n",
-    "\n"
+    ")"
    ]
   },
   {
@@ -370,15 +368,20 @@
     "tab = widgets.Tab()\n",
     "tab.children = children\n",
     "tab.titles = [str(i) for i in range(len(children))]\n",
-    "tab\n"
+    "tab"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Hiding cell contents\n",
-    "\n",
+    "## Hiding cell contents"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "You can use Jupyter Notebook **cell tags** to control some of the behavior of\n",
     "the rendered notebook. This uses the [**`sphinx-togglebutton`**](https://sphinx-togglebutton.readthedocs.io/en/latest/)\n",
     "package to add a little button that toggles the visibility of content.\n",
@@ -444,13 +447,6 @@
     "you want to highlight sections of a toggle-able section.\n",
     "```"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/myst_nb/parser.py
+++ b/myst_nb/parser.py
@@ -52,7 +52,11 @@ class NotebookParser(MystParser):
 
                 # If a markdown cell, simply call the Myst parser and append children
                 if cell["cell_type"] == "markdown":
-                    myst_ast = tokenize(cell["source"].splitlines(keepends=True))
+                    source = cell["source"]
+                    if not source.endswith("\n"):
+                        # Ensure we always end with a newline in case it's a one-liner
+                        source = source + "\n"
+                    myst_ast = tokenize(source.splitlines(keepends=True))
 
                     # Check for tag-specific behavior
                     if "hide_input" in cell.metadata.get("tags", []):


### PR DESCRIPTION
Because the myst-parser will parse a line as a paragraph if it's a one-liner, this adds a newline to make sure it's parsed as a heading if need be