### PR TITLE
using document and adding a more helpful error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -46,9 +46,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 #
 html_theme = "pandas_sphinx_theme"
 html_logo = "_static/logo.png"
-html_theme_options = {
-    "github_url": "https://github.com/ExecutableBookProject/myst-nb",
-}
+html_theme_options = {"github_url": "https://github.com/ExecutableBookProject/myst-nb"}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The primary tool this package provides is a Sphinx parser for `ipynb` files.
 This allows you to directly convert Jupyter Notebooks into Sphinx documents.
 It relies heavily on the [`MyST` parser](https://github.com/ExecutableBookProject/myst_parser).
 
-```{warn}
+```{warning}
 This project is in an alpha state. It may evolve rapidly and/or make breaking changes!
 It currently depends on a fork of the Mistletoe library, so keep that in mind as you
 use it!


### PR DESCRIPTION
This uses `Document` instead of tokenize, per @chrisjsewell 's latest comments about improvements to that class.

It also adds a simple try/except block to capture any errors associated with parsing the notebook and display a message that includes the notebook cell and path. @chrisjsewell do you think this is a reasonable way to handle this? Know of a better way to get the error message to display? I know it's not idea because the errors won't propagate past this step in Sphinx, but as a stopgap is it the right improvement?