### PR TITLE
Add `glu:` alternative to `glue:any`

### DIFF
--- a/myst_nb/nb_glue/domain.py
+++ b/myst_nb/nb_glue/domain.py
@@ -271,9 +271,9 @@ class NbGlueDomain(Domain):
     # - docmap is the mapping of docnames to the set of keys it contains
     initial_data = {"cache": {}, "docmap": {}}
 
-    directives = {"any": Paste, "figure": PasteFigure, "math": PasteMath}
+    directives = {"": Paste, "any": Paste, "figure": PasteFigure, "math": PasteMath}
 
-    roles = {"any": paste_any_role, "text": paste_text_role}
+    roles = {"": paste_any_role, "any": paste_any_role, "text": paste_text_role}
 
     @property
     def cache(self) -> dict:

--- a/tests/notebooks/with_glue.ipynb
+++ b/tests/notebooks/with_glue.ipynb
@@ -190,7 +190,7 @@
    "source": [
     "## Referencing the figs\n",
     "\n",
-    "{glu:any}`key_text1`, {glu:any}`key_plt`\n",
+    "{glu:any}`key_text1`, {glu:}`key_plt`\n",
     "\n",
     "```{glu:any} key_df\n",
     "```\n",
@@ -199,7 +199,7 @@
     "\n",
     "and formatted {glu:text}`key_float:.2f`\n",
     "\n",
-    "```{glu:any} key_plt\n",
+    "```{glu:} key_plt\n",
     "```\n",
     "\n",
     "and {glu:text}`key_undisplayed` inline...\n",


### PR DESCRIPTION
closes #78 you can't use `glue`, as they have to be under the same domain, but you can use `glu:`

@jstac @choldgraf 