### PR TITLE
DOCS: Remove extra pydata theme install

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,6 @@ To install `myst-nb`, do the following:
   cd MyST-NB
   git checkout master
   pip install -e .[code_style,testing,rtd]
-  pip install git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master
   ```
 
 * Enable the `myst_nb` extension in your Sphinx repository's extensions:


### PR DESCRIPTION
What @phaustin should have actually done in #92 lol (because it is now in the `rtd` extra)