### PR TITLE
Add equation example to basic.ipynb example jupyter notebook

### DIFF
--- a/docs/use/basic.ipynb
+++ b/docs/use/basic.ipynb
@@ -30,6 +30,18 @@
     "```\n",
     "````\n",
     "`````\n",
+    "Other MyST features like **equation numbering** can be used in notebooks:\n",
+    "\n",
+    "```{math} e^{i\\pi} + 1 = 0\n",
+    "---\n",
+    "label: euler\n",
+    "---\n",
+    "```\n",
+    "\n",
+    "Euler's identity, equation {math:numref}`euler`, was elected one of the\n",
+    "most beautiful mathematical formulas.\n",
+    "\n",
+    "You can see the syntax used for this example [here](https://myst-parser.readthedocs.io/en/latest/using/syntax.html#roles-an-in-line-extension-point).\n",
     "\n",
     "## Code cells and outputs\n",
     "\n",
@@ -258,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.1"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
@jstac from the discussion here https://github.com/ExecutableBookProject/meta/issues/45

I don't think the changed python version in the metadata will be a problem but I can revert it to 3.8.0 if you like and update this PR