### PR TITLE
Adding singlehtml key to render priority

### DIFF
--- a/myst_nb/transform.py
+++ b/myst_nb/transform.py
@@ -29,6 +29,7 @@ RENDER_PRIORITY = {
     "latex": ["text/latex", "text/plain"],
 }
 RENDER_PRIORITY["readthedocs"] = RENDER_PRIORITY["html"]
+RENDER_PRIORITY["singlehtml"] = RENDER_PRIORITY["html"]
 
 
 class CellOutputsToNodes(SphinxTransform):


### PR DESCRIPTION
This just adds another key to the render priority in case somebody is building `singlehtml`. It doesn't change functionality at all