### PR TITLE
DOC: Fixed typo in subsection heading

### DIFF
--- a/docs/use/glue.ipynb
+++ b/docs/use/glue.ipynb
@@ -210,7 +210,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### The `glu` role/directive\n",
+    "### The `glue` role/directive\n",
     "\n",
     "The simplest role and directive are `glue:any`,\n",
     "which paste the glued output inline or as a block respectively,\n",


### PR DESCRIPTION
Just a minor typo (I think) that I stumbled across while working my way through these docs. MyST-NB looks like it has some really nice features!

