### PR TITLE
packaging js with install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
-    package_data={"myst_nb": ["_static/mystnb.css"]},
+    package_data={"myst_nb": ["_static/*"]},
     install_requires=[
         "myst-parser~=0.8",
         "docutils>=0.15",


### PR DESCRIPTION
I missed the `setup.py` package update, this makes sure that anything inside `_static` gets packaged w/ myst-nb