### PR TITLE
output cell tweaks

### DIFF
--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -35,6 +35,7 @@ div.cell_input > div, div.cell_output div.output > div.highlight {
   padding-left: 1em;
   padding-right: 0em;
   margin-bottom: 1em;
+  margin-top: 1em;
 }
 
 /* Outputs from jupyter_sphinx overrides to remove extra CSS */
@@ -80,8 +81,6 @@ div.cell_output table {
     color: black;
     font-size: 1em;
     table-layout: fixed;
-    margin-left:auto;
-    margin-right:auto;
   }
   div.cell_output thead {
     border-bottom: 1px solid black;


### PR DESCRIPTION
Two main changes:

* Adds whitespace above the cell outputs (and closes https://github.com/ExecutableBookProject/quantecon-example/issues/5)
* Makes pandas dataframes snap to the left instead of being centered (which is in-line with how we treat all other outputs)

old: 

![image](https://user-images.githubusercontent.com/1839645/78590304-7c57a400-77f6-11ea-8cd7-1e0fb241454e.png)

new:

![image](https://user-images.githubusercontent.com/1839645/78590316-824d8500-77f6-11ea-834b-fff1641419bc.png)

(forgive the left margins, those haven't changed it's just a matter of where I took the screenshot)
example: https://354-241268229-gh.circle-artifacts.com/0/html/use/glue.html

@jstac what do you think?