### PR TITLE
tags use hyphens now

### DIFF
--- a/docs/use/glue.md
+++ b/docs/use/glue.md
@@ -61,7 +61,7 @@ to focus on the glueing part.
 +++
 
 ```{code-cell} ipython3
-:tags: [hide_cell]
+:tags: [hide-cell]
 
 # Simulate some data and bootstrap the mean of the data
 import numpy as np
@@ -128,7 +128,7 @@ glue("df_tbl", df)
 
 ```{tip}
 Since we are going to paste this figure into our document at a later point,
-you may wish to remove the output here, using the `remove_output` tag
+you may wish to remove the output here, using the `remove-output` tag
 (see {ref}`use/removing`).
 ```
 

--- a/docs/use/hiding.md
+++ b/docs/use/hiding.md
@@ -29,47 +29,47 @@ You can **cell tags** to control the content hidden with code cells.
 Add the following tags to a cell's metadata to control
 what to hide in code cells:
 
-* **`hide_input`** tag to hide the cell inputs
-* **`hide_output`** to hide the cell outputs
-* **`hide_cell`** to hide the entire cell
+* **`hide-input`** tag to hide the cell inputs
+* **`hide-output`** to hide the cell outputs
+* **`hide-cell`** to hide the entire cell
 
 For example, we'll show cells with each below.
 
 ```{code-cell} ipython3
-:tags: [remove_cell]
+:tags: [remove-cell]
 
 import matplotlib.pyplot as plt
 import numpy as np
 data = np.random.rand(2, 100) * 100
 ```
 
-Here is a cell with a `hide_input` tag. Click the "toggle" button to the
+Here is a cell with a `hide-input` tag. Click the "toggle" button to the
 right to show it.
 
 ```{code-cell} ipython3
-:tags: [hide_input]
+:tags: [hide-input]
 
-# This cell has a hide_input tag
+# This cell has a hide-input tag
 fig, ax = plt.subplots()
 ax.scatter(*data, c=data[0], s=data[0])
 ```
 
-Here's a cell with a `hide_output` tag:
+Here's a cell with a `hide-output` tag:
 
 ```{code-cell} ipython3
-:tags: [hide_output]
+:tags: [hide-output]
 
-# This cell has a hide_output tag
+# This cell has a hide-output tag
 fig, ax = plt.subplots()
 ax.scatter(*data, c=data[0], s=data[0])
 ```
 
-And the following cell has a `hide_cell` tag:
+And the following cell has a `hide-cell` tag:
 
 ```{code-cell} ipython3
-:tags: [hide_cell]
+:tags: [hide-cell]
 
-# This cell has a hide_cell tag
+# This cell has a hide-cell tag
 fig, ax = plt.subplots()
 ax.scatter(*data, c=data[0], s=data[0])
 ```
@@ -78,14 +78,14 @@ ax.scatter(*data, c=data[0], s=data[0])
 
 # Hiding markdown cells
 
-There are two ways to hide markdown cells. First, **you can add the `hide_input`**
+There are two ways to hide markdown cells. First, **you can add the `hide-input`**
 cell metadata. This triggers the same hiding behavior described above for
 code cells.
 
-+++ {"tags": ["hide_input"]}
++++ {"tags": ["hide-input"]}
 
 ```{note}
-This cell was hidden by adding a `hide_input` tag to it!
+This cell was hidden by adding a `hide-input` tag to it!
 ```
 
 +++
@@ -139,40 +139,40 @@ Sometimes, you want to entirely remove parts of a cell so that it doesn't make i
 into the output at all. To do this, you can use the same tag pattern described above,
 but with the word `remove_` instead of `hide_`. Use the following tags:
 
-* **`remove_input`** tag to remove the cell inputs
-* **`remove_output`** to remove the cell outputs
-* **`remove_cell`** to remove the entire cell
+* **`remove-input`** tag to remove the cell inputs
+* **`remove-output`** to remove the cell outputs
+* **`remove-cell`** to remove the entire cell
 
 +++
 
-Here is a cell with a `remove_input` tag. The inputs will not make it into
+Here is a cell with a `remove-input` tag. The inputs will not make it into
 the page at all.
 
 ```{code-cell} ipython3
-:tags: [remove_input]
+:tags: [remove-input]
 
-# This cell has a remove_input tag
+# This cell has a remove-input tag
 fig, ax = plt.subplots()
 ax.scatter(*data, c=data[0], s=data[0])
 ```
 
-Here's a cell with a `remove_output` tag:
+Here's a cell with a `remove-output` tag:
 
 ```{code-cell} ipython3
-:tags: [remove_output]
+:tags: [remove-output]
 
-# This cell has a remove_output tag
+# This cell has a remove-output tag
 fig, ax = plt.subplots()
 points = ax.scatter(*data, c=data[0], s=data[0])
 ```
 
-And the following cell has a `remove_cell` tag (there should be nothing
+And the following cell has a `remove-cell` tag (there should be nothing
 below, since the cell will be gone).
 
 ```{code-cell} ipython3
-:tags: [remove_cell]
+:tags: [remove-cell]
 
-# This cell has a remove_cell tag
+# This cell has a remove-cell tag
 fig, ax = plt.subplots()
 points = ax.scatter(*data, c=data[0], s=data[0])
 ```

--- a/docs/use/markdown.md
+++ b/docs/use/markdown.md
@@ -76,7 +76,7 @@ for example those discussed in {ref}`use/hiding/code`:
 
 ````md
 ```{code-cell} ipython3
-:tags: [hide_output]
+:tags: [hide-output]
 
 for i in range(20):
     print("Millhouse did not test cootie positive")
@@ -86,7 +86,7 @@ for i in range(20):
 Yields the following:
 
 ```{code-cell} ipython3
-:tags: [hide_output]
+:tags: [hide-output]
 
 for i in range(20):
     print("Millhouse did not test cootie positive")

--- a/myst_nb/__init__.py
+++ b/myst_nb/__init__.py
@@ -53,8 +53,11 @@ def set_valid_execution_paths(app):
 def update_togglebutton_classes(app, config):
     to_add = [
         ".tag_hide_input div.cell_input",
+        ".tag_hide-input div.cell_input",
         ".tag_hide_output div.cell_output",
+        ".tag_hide-output div.cell_output",
         ".tag_hide_cell.cell",
+        ".tag_hide-cell.cell",
     ]
     for selector in to_add:
         config.togglebutton_selector += f", {selector}"

--- a/myst_nb/parser.py
+++ b/myst_nb/parser.py
@@ -130,7 +130,7 @@ def nb_to_tokens(ntbk: nbf.NotebookNode) -> Tuple[MarkdownIt, AttrDict, List[Tok
         # skip cells tagged for removal
         # TODO this logic should be deferred to a transform
         tags = nb_cell.metadata.get("tags", [])
-        if "remove_cell" in tags:
+        if ("remove_cell" in tags) or ("remove-cell" in tags):
             continue
 
         if nb_cell["cell_type"] == "markdown":
@@ -219,7 +219,7 @@ class SphinxNBRenderer(SphinxRenderer):
             classes.append(f"tag_{tag}")
         sphinx_cell = CellNode(classes=classes, cell_type=cell["cell_type"])
         self.current_node += sphinx_cell
-        if "remove_input" not in tags:
+        if ("remove_input" not in tags) and ("remove-input" not in tags):
             cell_input = CellInputNode(classes=["cell_input"])
             sphinx_cell += cell_input
 
@@ -230,7 +230,11 @@ class SphinxNBRenderer(SphinxRenderer):
         # ==================
         # Cell output
         # ==================
-        if "remove_output" not in tags and cell["outputs"]:
+        if (
+            ("remove_output" not in tags)
+            and ("remove-output" not in tags)
+            and cell["outputs"]
+        ):
             cell_output = CellOutputNode(classes=["cell_output"])
             sphinx_cell += cell_output
 


### PR DESCRIPTION
This updates our tags behavior so that it allows for hyphenated versions as well as underscores (ideally we'd totally switch but I'm keeping underscores for legacy support). So now:

`hide_input` -> `hide-input`

and so on.

This is more in-line with other jupyter tagging conventions such as `raises-exception`.

None of the actual behavior should change...here's the page where we describe this for reference:

https://385-241268229-gh.circle-artifacts.com/0/html/use/hiding.html

it should be no different than

https://myst-nb.readthedocs.io/en/latest/use/hiding.html