### PR TITLE
fixing relpath bug

### DIFF
--- a/myst_nb/cache.py
+++ b/myst_nb/cache.py
@@ -155,7 +155,8 @@ def add_notebook_outputs(env, ntbk, file_path=None):
         return ntbk
 
     cache_base = get_cache(path_cache)
-    r_file_path = Path(file_path).relative_to(Path(file_path).cwd())
+    # Use relpath here in case Sphinx is building from a non-parent folder
+    r_file_path = Path(os.path.relpath(file_path, Path().resolve()))
 
     try:
         _, ntbk = cache_base.merge_match_into_notebook(ntbk)


### PR DESCRIPTION
This is a bug that is difficult to reproduce because it only happens when you build the documentation from a folder that is not strictly in the parent tree of the build folder. By that I mean a folder structure like this:

This works:
```
# Path to documentation
run/build/from/this/folder/path/to/docs
# Sphinx build command is run from here
run/build/from/this/folder
```

This raises an error:
```
# Path to documentation
run/build/from/this/folder/path/to/docs
# Sphinx build command is run from here
run/build/from/this/other/folder
```

The problem is in Pathlib somewhere when it is calling `relative_to`. This method only works if the two items share the same root, which isn't true in the second case above. So this PR just uses relpath.