### PR TITLE
github action conditions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: continuous-integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   pre-commit:


### PR DESCRIPTION
I found that we have duplicate tests running because our github action runs on both pull_request and push. I believe that this configuration will make it run only once for forked pull requests so we don't duplicate test jobs