### PR TITLE
inline images in tables size

### DIFF
--- a/myst_nb/_static/mystnb.css
+++ b/myst_nb/_static/mystnb.css
@@ -117,3 +117,7 @@ span.pasted-text {
 span.pasted-inline img {
   max-height: 2em;
 }
+
+tbody span.pasted-inline img {
+  max-height: none;
+}


### PR DESCRIPTION
This removes the max height restriction for images that are `glue-pasted` into tables, so they aren't too tiny.

Current:
![image](https://user-images.githubusercontent.com/1839645/79596736-f52beb00-8095-11ea-9d58-8c0387bbb0e8.png)

Updated:
![image](https://user-images.githubusercontent.com/1839645/79596717-e8a79280-8095-11ea-9346-99c6f03ec35f.png)

It's not a huge difference but at least enough that @martinagvilas noticed 😄 